### PR TITLE
Improve street anonymization regex

### DIFF
--- a/backend/temp_ruleengine/utils/anonymizeText.js
+++ b/backend/temp_ruleengine/utils/anonymizeText.js
@@ -3,7 +3,7 @@ function anonymizeText(text) {
   return text
     .replace(/([A-ZÄÖÜ][a-zäöüß]+\s[A-ZÄÖÜ][a-zäöüß]+)/g, '***NAME***')
     .replace(/\b(\d{5})\b/g, '*****')
-    .replace(/(\b\w+straße\b|\b\w+weg\b|\b\w+allee\b)/gi, '***STRASSE***')
+    .replace(/\b[\p{L}\d]+(?:straße|weg|allee)\b/giu, '***STRASSE***')
     .replace(/(\+?\d{2,4}[-.\s]?\d{3,})/g, '***TEL***');
 }
 


### PR DESCRIPTION
## Summary
- broaden street name anonymization to include Unicode characters

## Testing
- `npm test` (fails: Missing script)


------
https://chatgpt.com/codex/tasks/task_e_688fcff9165c832abd7c5ffc4c3132ac